### PR TITLE
Merchant moe integration, optimize rpc call

### DIFF
--- a/integrations/merchantmoe_lbt_integration.py
+++ b/integrations/merchantmoe_lbt_integration.py
@@ -11,7 +11,7 @@ from constants.merchantmoe import (
     METH_USDE_MERCHANT_MOE_LBT_CONTRACT,
 )
 from models.integration import Integration
-from utils.merchantmoe import lb_pair_contract, liquidity_helper_contract, chunks
+from utils.merchantmoe import lb_pair_contract, liquidity_helper_contract
 from utils.web3_utils import W3_BY_CHAIN, fetch_events_logs_with_retry, call_with_retry
 
 
@@ -48,18 +48,16 @@ class MerchantMoeIntegration(Integration):
         lower_bin_bound = active_id - 183
         upper_bin_bound = active_id + 183
         bin_range = list(range(lower_bin_bound, upper_bin_bound + 1))
-        bin_chunks = list(chunks(bin_range, 5))
 
         total_liquidity = 0
-        for chunk in bin_chunks:
-            logging.info(f"[{self.name}] Calling Liquidity Helper Contract for User: {user}, for bin ids: {chunk}")
-            liquidity = call_with_retry(
-                self.liquidity_helper_contract.functions.getLiquiditiesOf(
-                    METH_USDE_MERCHANT_MOE_LBT_CONTRACT, user, chunk
-                ),
-                block
-            )
-            total_liquidity += sum(liquidity)
+        logging.info(f"[{self.name}] Calling Liquidity Helper Contract for User: {user}, for bin ids: {bin_range}")
+        liquidity = call_with_retry(
+            self.liquidity_helper_contract.functions.getLiquiditiesOf(
+                METH_USDE_MERCHANT_MOE_LBT_CONTRACT, user, bin_range
+            ),
+            block
+        )
+        total_liquidity += sum(liquidity)
 
         total_liquidity = round(total_liquidity / 10**18, 8)
 

--- a/utils/merchantmoe.py
+++ b/utils/merchantmoe.py
@@ -18,8 +18,3 @@ merchant_moe_liquidity_helper_abi = json.load(
 
 lb_pair_contract = w3_mantle.eth.contract(address=METH_USDE_MERCHANT_MOE_LBT_CONTRACT, abi=merchant_moe_lb_pair_abi)
 liquidity_helper_contract = w3_mantle.eth.contract(address=MERCHANT_MOE_LIQUIDITY_HELPER_CONTRACT, abi=merchant_moe_liquidity_helper_abi)
-
-
-def chunks(lst, n):
-    for i in range(0, len(lst), n):
-        yield lst[i:i + n]


### PR DESCRIPTION
- this PR removes the iterative rpc calls to `getLiquiditiesOf()` which will reduce the total rpc calls in `getBalance` from 74 to 1
- during testing we used a paid infura rpc service which were limited by either aggressive timeouts or low gas limits, as such  when calling `getLiquiditiesOf()` with the full bin range "out of gas" errors were encountered, to circumvent this bin ranges were batched to 5 bins at a time
- upon further investigation and testing requested by Dan from the Ethena team to reduce the number of rpc calls we discovered the public mantle rpc was able to handle the call to `getLiquiditiesOf()` with the full bin range