### PR TITLE
fix duplicate in Enum

### DIFF
--- a/constants/chains.py
+++ b/constants/chains.py
@@ -9,5 +9,4 @@ class Chain(Enum):
     BLAST = "Blast"
     SCROLL = "Scroll"
     MODE = "Mode"
-    FRAXTAL = "Fraxtal"
     OPTIMISM = "Optimism"


### PR DESCRIPTION
was getting this error:

```
Traceback (most recent call last):
  File "/code/ethena_sats_adapters/integrations/hyperdrive.py", line 3, in <module>
    from constants.chains import Chain
  File "/code/ethena_sats_adapters/constants/chains.py", line 4, in <module>
    class Chain(Enum):
  File "/code/ethena_sats_adapters/constants/chains.py", line 12, in Chain
    FRAXTAL = "Fraxtal"
  File "/usr/lib64/python3.10/enum.py", line 134, in __setitem__
    raise TypeError('Attempted to reuse key: %r' % key)
TypeError: Attempted to reuse key: 'FRAXTAL'
```