### PR TITLE
feat: add support for multiple Rumpel pools and add s4 sats pool

### DIFF
--- a/constants/chains.py
+++ b/constants/chains.py
@@ -15,5 +15,4 @@ class Chain(Enum):
     SOLANA = "Solana"
     APTOS = "Aptos"
     BASE = "Base"
-    APTOS = "Aptos"
     SEPOLIA = "Sepolia"

--- a/constants/rumpel.py
+++ b/constants/rumpel.py
@@ -1,13 +1,10 @@
 import json
 from web3 import Web3
 from utils.web3_utils import w3
+from dataclasses import dataclass
 
-KPSAT3_ADDRESS = Web3.to_checksum_address("0x263b0f5e179c1d72B884C43105C620d2112dF2a0")
-SENA_ADDRESS = Web3.to_checksum_address("0x8bE3460A480c80728a8C4D7a5D5303c85ba7B3b9")
-
-KPSATS3_SENA_UNIV3_POOL_DEPLOYED_BLOCK = 21383217;
-KPSATS3_SENA_UNIV3_POOL_ADDRESS = Web3.to_checksum_address("0x5D29647b684Ce835F442915cC3C8e99aAb2A26C6")
 UNIV3_NONFUNGUBLE_POSITION_MANAGER_ADDRESS = Web3.to_checksum_address("0xC36442b4a4522E871399CD717aBDD847Ab11FE88")
+SENA_ADDRESS = Web3.to_checksum_address("0x8bE3460A480c80728a8C4D7a5D5303c85ba7B3b9")
 
 with open("abi/univ3_nonfungible_position_manager.json") as f:
     UNIV3_NONFUNGIBLE_POSITION_MANAGER_ABI = json.load(f)
@@ -20,7 +17,25 @@ UNIV3_NONFUNGIBLE_POSITION_MANAGER_CONTRACT = w3.eth.contract(
 with open("abi/univ3_pool.json") as f:
     UNIV3_POOL_ABI = json.load(f)
 
-KPSATS3_SENA_UNIV3_POOL_CONTRACT = w3.eth.contract(
-    address=KPSATS3_SENA_UNIV3_POOL_ADDRESS,
-    abi=UNIV3_POOL_ABI,
-)
+@dataclass
+class KPSATSPool:
+    name: str
+    deployed_block: int
+    kpsats_address: str
+    pool_address: str
+
+KPSATS_POOLS = [
+    KPSATSPool(
+        name="KPSATS3",
+        deployed_block=21383217,
+        kpsats_address=Web3.to_checksum_address("0x263b0f5e179c1d72B884C43105C620d2112dF2a0"),
+        pool_address=Web3.to_checksum_address("0x5D29647b684Ce835F442915cC3C8e99aAb2A26C6")
+    ),
+    KPSATSPool(
+        name="KPSATS4",
+        deployed_block=22333279,
+        kpsats_address=Web3.to_checksum_address("0x8659c0994C8EC73A66E7587c4c6b3aB38d1223bE"),
+        pool_address=Web3.to_checksum_address("0x4d5a1035c8d44163c554ec8027b5db8c819c66b2")
+    )
+]
+


### PR DESCRIPTION
### Background / Context
Rumpel pools allow trading between tokenized sats and sENA. This integration allows LPs to still earn SATS on their LP'd sENA. Each of Ethena's new point seasons require a new SAT point token and a new pool.

### This Change
This update allows for LPs in the new S4 SATS pool to have their SATS redirected from the uni pool to their address. The core logic remains the same, it is just expanded to iterate on multiple pools.

### Test 
Added test at block 22375313 -- the summed result of user balances equals the pool balance per etherscan.

Results:
22375313: {
'0xb8C42c0Fe5bC45336d001963b52C45Edd476438C': 9711.80906591243, '0x0E9D806e354eB4235958A294FDEf09D18862C02c': 100000.00000002698}
}

![image](https://github.com/user-attachments/assets/06f7fdab-de73-4091-8ee4-523e0a182396)

### Additional Note
A duplicate definition of `APTOS = "Aptos"` in constants/chains.py was causing an error, so removed it.