### PR TITLE
Farmix Integration For Ethena points in stonfi lp pools

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@kamino-finance/klend-sdk": "^3.2.7",
     "@solana/web3.js": "^1.95.2",
     "dotenv": "^16.4.5",
-    "@aptos-labs/ts-sdk": "1.33.1"
+    "@aptos-labs/ts-sdk": "1.33.1",
+    "@ton/core": "~0.60.1",
+    "axios": "^1.8.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@solana/web3.js':
         specifier: ^1.95.2
         version: 1.95.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@ton/core':
+        specifier: ~0.60.1
+        version: 0.60.1(@ton/crypto@3.3.0)
+      axios:
+        specifier: ^1.8.0
+        version: 1.9.0
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -370,6 +376,17 @@ packages:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
 
+  '@ton/core@0.60.1':
+    resolution: {integrity: sha512-8FwybYbfkk57C3l9gvnlRhRBHbLYmeu0LbB1z9N+dhDz0Z+FJW8w0TJlks8CgHrAFxsT3FlR2LsqFnsauMp38w==}
+    peerDependencies:
+      '@ton/crypto': '>=3.2.0'
+
+  '@ton/crypto-primitives@2.1.0':
+    resolution: {integrity: sha512-PQesoyPgqyI6vzYtCXw4/ZzevePc4VGcJtFwf08v10OevVJHVfW238KBdpj1kEDQkxWLeuNHEpTECNFKnP6tow==}
+
+  '@ton/crypto@3.3.0':
+    resolution: {integrity: sha512-/A6CYGgA/H36OZ9BbTaGerKtzWp50rg67ZCH2oIjV1NcrBaCK9Z343M+CxedvM7Haf3f/Ee9EhxyeTp0GKMUpA==}
+
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
@@ -450,8 +467,8 @@ packages:
   axios@1.7.4:
     resolution: {integrity: sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==}
 
-  axios@1.7.9:
-    resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
+  axios@1.9.0:
+    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1041,6 +1058,9 @@ packages:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
 
+  jssha@3.2.0:
+    resolution: {integrity: sha512-QuruyBENDWdN4tZwJbQq7/eAK85FqrI4oDbXjy5IBhYD+2pTJyBUWZe8ctWaCkrV0gy6AaelgOZZBMeswEa/6Q==}
+
   jwt-decode@4.0.0:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
@@ -1335,6 +1355,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  symbol.inspect@1.0.1:
+    resolution: {integrity: sha512-YQSL4duoHmLhsTD1Pw8RW6TZ5MaTX5rXJnqacJottr2P2LZBF/Yvrc3ku4NUpMOm8aM0KOCqM+UAkMA5HWQCzQ==}
+
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
@@ -1366,6 +1389,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
@@ -1762,7 +1788,7 @@ snapshots:
       '@solana/spl-token': 0.3.11(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@switchboard-xyz/sbv2-lite': 0.1.6(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      axios: 1.7.9
+      axios: 1.9.0
       bn.js: 5.2.1
       buffer: 6.0.3
       buffer-layout: 1.2.2
@@ -1791,7 +1817,7 @@ snapshots:
       '@raydium-io/raydium-sdk': 1.3.1-beta.5(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)(utf-8-validate@5.0.10)
       '@solana/spl-token': 0.4.9(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      axios: 1.7.9
+      axios: 1.9.0
       bn.js: 5.2.1
       bs58: 6.0.0
       decimal.js: 10.4.3
@@ -2014,7 +2040,7 @@ snapshots:
       '@solana/buffer-layout': 4.0.1
       '@solana/spl-token': 0.3.11(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      axios: 1.7.9
+      axios: 1.9.0
       big.js: 6.2.2
       bn.js: 5.2.1
       decimal.js: 10.4.3
@@ -2277,6 +2303,21 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
+  '@ton/core@0.60.1(@ton/crypto@3.3.0)':
+    dependencies:
+      '@ton/crypto': 3.3.0
+      symbol.inspect: 1.0.1
+
+  '@ton/crypto-primitives@2.1.0':
+    dependencies:
+      jssha: 3.2.0
+
+  '@ton/crypto@3.3.0':
+    dependencies:
+      '@ton/crypto-primitives': 2.1.0
+      jssha: 3.2.0
+      tweetnacl: 1.0.3
+
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.0.4
@@ -2374,7 +2415,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.7.9:
+  axios@1.9.0:
     dependencies:
       follow-redirects: 1.15.9
       form-data: 4.0.1
@@ -2973,6 +3014,8 @@ snapshots:
 
   jsonparse@1.3.1: {}
 
+  jssha@3.2.0: {}
+
   jwt-decode@4.0.0: {}
 
   keyv@4.5.4:
@@ -3270,6 +3313,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol.inspect@1.0.1: {}
+
   test-exclude@6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.3
@@ -3296,6 +3341,8 @@ snapshots:
   traverse-chain@0.1.0: {}
 
   tslib@2.8.1: {}
+
+  tweetnacl@1.0.3: {}
 
   type-fest@0.8.1: {}
 

--- a/ts/farmix_position_check.ts
+++ b/ts/farmix_position_check.ts
@@ -1,0 +1,69 @@
+import * as dotenv from "dotenv";
+import axios from 'axios'
+import { Cell } from "@ton/core";
+
+dotenv.config();
+
+const config = {
+  tonConsoleBaseUrl: process.env.TON_CONSOLE_BASE_URL || 'https://tonapi.io',
+  tonConsoleApiToken: process.env.TON_CONSOLE_API_TOKEN
+}
+
+const client = axios.create({
+  baseURL: config.tonConsoleBaseUrl,
+  headers: config.tonConsoleApiToken
+    ? { 'Authorization': `Bearer ${config.tonConsoleApiToken}` }
+    : {}
+})
+
+const args = process.argv.slice(2);
+const contractAddress = args[0];
+
+interface IsFarmixPositionCheckResult {
+  is_position: boolean,
+  err?: string
+  owner_addr?: string
+}
+
+
+
+async function isContractFarmixPosition() {
+  const result: IsFarmixPositionCheckResult = {
+    is_position: false
+  }
+
+  try {
+    const res = await client.get(`v2/blockchain/accounts/${contractAddress}/methods/get_identity`);
+    if (!res.data.success || res.data.exit_code !== 0) {
+      console.log(JSON.stringify(result))
+
+      return
+    }
+    const stack = res.data.stack
+    const ownerAddrTupleItem = stack[4]
+    if (!ownerAddrTupleItem || ownerAddrTupleItem?.type !== 'cell' || !ownerAddrTupleItem.cell) {
+      console.log(JSON.stringify(result))
+
+      return
+    }
+    const ownerAddrCell = Cell.fromHex(ownerAddrTupleItem.cell)
+    const ownerAddr = ownerAddrCell.beginParse().loadAddress();
+
+    result.is_position = true;
+    result.owner_addr = ownerAddr.toString({ urlSafe: true, bounceable: true  });
+
+    console.log(JSON.stringify(result));
+  } catch (err: any) {
+    result.err = err?.message ?? 'unknown error'
+
+    console.log(JSON.stringify(result))
+  }
+}
+
+isContractFarmixPosition();
+
+
+
+
+
+


### PR DESCRIPTION
Hi ethena team! In this pr we want to add support for farmix (https://farmix.tg) positions in ston.fi usdt/usde pool. 
We are leveraged yield farming protocol and allow our users to take leverage on providing liquidity to ston.fi pool. 

Technically the position is a separated contract and now ston.fi adapter will threat farmix position a liquidity owner. This pr fixes this by add check in ston.fi adapter - if liquidity provider is farmix position it will be replaced by position owner.

We didn't write our own adapter because this will results in points duplicating and even if positions wouldn't claim them this can affect distribution, also modifying ston.fi provider results in cleaner code in out opinion)

We use ton-console (tonapi) for executing contract get method, but any ton api can be used with little modifications.

 