### PR TITLE
chore: add uv exclude-newer = "10 days" constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
 ]
 
 [tool.uv]
+exclude-newer = "10 days"
 override-dependencies = [
     "aiohttp>=3.13.4",
     "Pygments>=2.20.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">3.12, <3.13"
 
+[options]
+exclude-newer = "2026-05-08T12:04:28.027911Z"
+exclude-newer-span = "P10D"
+
 [manifest]
 overrides = [
     { name = "aiohttp", specifier = ">=3.13.4" },


### PR DESCRIPTION
## What
Add `exclude-newer = "10 days"` to `[tool.uv]` in `pyproject.toml`.

## Why
Prevents uv from resolving packages published in the last 10 days, providing a stability buffer against newly published packages that may introduce unexpected issues. Closes PE-1840.

## Test plan
- `uv lock` ran successfully with the new constraint applied