### PR TITLE
chore(deps): upgrade to pnpm 11 and harden supply-chain config

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,23 +22,8 @@
     "form-data": "^4.0.4",
     "js-yaml": "^3.14.2"
   },
-  "pnpm": {
-    "overrides": {
-      "bigint-buffer": "npm:bigint-buffer-fixed@^1.1.5",
-      "tar": ">=7.5.11",
-      "minimatch": ">=3.1.4",
-      "axios": ">=1.15.2",
-      "axios@1.14.1": "1.15.2",
-      "axios@0.30.4": "0.30.3",
-      "brace-expansion@<1.1.13": "1.1.13",
-      "brace-expansion@>=4.0.0 <5.0.6": "5.0.6",
-      "ip-address@<=10.1.0": "10.1.1",
-      "uuid@11.1.0": "11.1.1",
-      "plain-crypto-js@4.2.1": "0.0.0-security",
-      "lodash": ">=4.18.1",
-      "bn.js": ">=5.2.3",
-      "base-x": "^5.0.1",
-      "@tootallnate/once": ">=3.0.1"
-    }
+  "packageManager": "pnpm@11.3.0",
+  "engines": {
+    "node": ">=22.13"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,42 @@
+# pnpm-specific settings live here. pnpm v11 no longer reads the package.json
+# "pnpm" field, nor non-auth/registry settings from .npmrc.
+
+# Supply-chain hardening
+# Refuse to install package versions younger than 10 days
+minimumReleaseAge: 14400
+# Fail (don't silently downgrade) if a package's publisher trust level drops
+trustPolicy: no-downgrade
+# Known-benign provenance downgrades, vetted and exempted from no-downgrade.
+# Each is a maintainer that stopped publishing with npm provenance (not an
+# attack). See nodejs/undici#4666.
+trustPolicyExclude:
+  - undici-types
+  # semver@6.3.1 (npm's own package) published without provenance; benign
+  - semver
+# Transitive deps must resolve from the registry, not git/tarball sources
+blockExoticSubdeps: true
+
+# Security CVE pins migrated verbatim from the former package.json#pnpm.overrides
+overrides:
+  "bigint-buffer": "npm:bigint-buffer-fixed@^1.1.5"
+  "tar": ">=7.5.11"
+  "minimatch": ">=3.1.4"
+  "axios": ">=1.15.2"
+  "axios@1.14.1": "1.15.2"
+  "axios@0.30.4": "0.30.3"
+  "brace-expansion@<1.1.13": "1.1.13"
+  "brace-expansion@>=4.0.0 <5.0.6": "5.0.6"
+  "ip-address@<=10.1.0": "10.1.1"
+  "uuid@11.1.0": "11.1.1"
+  "plain-crypto-js@4.2.1": "0.0.0-security"
+  "lodash": ">=4.18.1"
+  "bn.js": ">=5.2.3"
+  "base-x": "^5.0.1"
+  "@tootallnate/once": ">=3.0.1"
+
+# Dependencies permitted to run install/build scripts.
+allowBuilds:
+  bigint-buffer-fixed: true # native, replaces bigint-buffer via override
+  bufferutil: true # ws perf addon
+  utf-8-validate: true # ws perf addon
+  es5-ext: false # install script is a donation notice, not functional


### PR DESCRIPTION
## What
Onboard to pnpm `11.3.0` + supply-chain hardening. Part of **PE-1866**.

## Changes
- Add `packageManager: pnpm@11.3.0` (was unpinned); add `engines.node: ">=22.13"`
- Moved 15 security override pins from `package.json#pnpm.overrides` → `pnpm-workspace.yaml` (verbatim). ⚠️ Would have silently stopped applying under v11.
- New policies: `minimumReleaseAge: 14400` (10d), `trustPolicy: no-downgrade`, `blockExoticSubdeps: true`
- **No CI changes** (Python workflow; no pnpm steps)

### trustPolicyExclude
`undici-types`, `semver` — vetted benign provenance gaps

### allowBuilds
- **true:** `bigint-buffer-fixed` (native, replaces `bigint-buffer` via override), `bufferutil`, `utf-8-validate` (ws perf addons)
- **false:** `es5-ext` — install script is a donation notice, not a build

## Test plan
`pnpm install` under pnpm 11.3.0 / Node 22.22 succeeds; build scripts as configured.

## Security & Data Impact
**Security impact:** Adds install-time supply-chain protections; preserves override pins (notably `bigint-buffer` → `bigint-buffer-fixed` security override).
**Data classification affected:** None.

## Rollback
Revert commit — no state migration.