### PR TITLE
fix(security): pin tar to 7.5.20 for CVE-2026-59873

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   bigint-buffer: npm:bigint-buffer-fixed@^1.1.5
-  tar: '>=7.5.11'
+  tar: 7.5.20
   minimatch: '>=3.1.4'
   axios: '>=1.16.0'
   axios@1.14.1: '>=1.16.0'
@@ -1622,8 +1622,8 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+  tar@7.5.20:
+    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
     engines: {node: '>=18'}
 
   test-exclude@6.0.0:
@@ -2870,7 +2870,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 9.0.1
-      tar: 7.5.16
+      tar: 7.5.20
       unique-filename: 2.0.1
     transitivePeerDependencies:
       - bluebird
@@ -3627,7 +3627,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.8.5
-      tar: 7.5.16
+      tar: 7.5.20
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -3895,7 +3895,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  tar@7.5.16:
+  tar@7.5.20:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,11 @@ blockExoticSubdeps: true
 # Security CVE pins migrated verbatim from the former package.json#pnpm.overrides
 overrides:
   "bigint-buffer": "npm:bigint-buffer-fixed@^1.1.5"
-  "tar": ">=7.5.11"
+  # GHSA-23hp-3jrh-7fpw / CVE-2026-59873 (CRITICAL): every tar <= 7.5.18 is
+  # vulnerable to a decompression/parse DoS via unlimited input, so the old
+  # `>=7.5.11` floor still resolved into the vulnerable range (7.5.16). Pinned
+  # exactly: 7.5.20 is the newest release that clears `minimumReleaseAge` above.
+  "tar": "7.5.20"
   "minimatch": ">=3.1.4"
   "axios": ">=1.16.0"
   "axios@1.14.1": ">=1.16.0"


### PR DESCRIPTION
## What

Pin the `tar` override to 7.5.20 to remediate CVE-2026-59873 (CRITICAL).

## Why

[GHSA-23hp-3jrh-7fpw](https://github.com/advisories/GHSA-23hp-3jrh-7fpw) / CVE-2026-59873 — *node-tar: Decompression/parse DoS via unlimited input*, published 2026-07-20, CRITICAL. `tar` bounds neither the volume of data it will decompress nor the size of a parsed entry, so a small crafted archive can exhaust memory or CPU in the consuming process. Fixed upstream in **7.5.19**.

The advisory range is `<= 7.5.18` — **every published `tar` version up to and including 7.5.18 is affected, including the entire 6.x line.**

The existing override was already unscoped (`"tar": ">=7.5.11"`), but a `>=` floor does not keep a lockfile out of a range that later becomes vulnerable: `main` resolved to `tar@7.5.16`, squarely inside the advisory range. Replaced with an exact pin so the resolved version is auditable and cannot drift back.

**Why 7.5.20 and not the newest 7.5.22:** this repo enforces `minimumReleaseAge: 14400` (10 days) as supply-chain hardening. 7.5.21 (6 days old) and 7.5.22 (3 days old) would be rejected by that gate. 7.5.20 (published 2026-07-12, 15 days old) is the newest release that clears it.

### Exposure

`tar` is reached by two paths, both build/install-time only:

```
cacache@16.1.3   → tar
node-gyp@9.4.1   → tar
```

Both are native-module build plumbing pulled in by the JS-side tooling. No adapter or ETL code path unpacks untrusted archives, so real-world exploitability here is low despite the CRITICAL rating. The pin is still the right call: it clears the Dependabot alert and removes the primitive.

Note this repo's Python dependency tree (`pyproject.toml` / `uv.lock`) is untouched — the advisory is npm-only.

## Test plan

No production code changed — this is a dependency resolution pin, so there is no behaviour for a new unit or acceptance test to assert against. Verification is on the lockfile:

- `pnpm install --lockfile-only` regenerated cleanly.
- `pnpm install --lockfile-only --frozen-lockfile` passes → the lockfile satisfies the manifest, and **`✓ Lockfile passes supply-chain policies (446 entries)`** confirms 7.5.20 clears both `minimumReleaseAge` and `trustPolicy: no-downgrade`.
- Post-change lockfile scan: the only `tar` entries are `tar@7.5.20`; grep for `^  tar@(6\.|7\.[0-4]|7\.5\.([0-9]|1[0-8])):` returns nothing.
- **Diff scope verified mechanically**: comparing the set of resolved `pkg@version` keys before and after, `tar` is the *only* package whose resolved version changed. The diff is 11 insertions / 7 deletions across exactly two files, with no unrelated churn at all.
- CI to confirm on this PR: full `pnpm install` and the existing suites.

## Security & data impact

**Security impact:** Remediates one CRITICAL DoS advisory in a build-time transitive dependency. No change to auth, crypto, secrets, or data flows.
**Data classification affected:** None.
**Audit log updated:** n/a — this repo has no `SECURITY.md`, so the rationale lives in the override comment in `pnpm-workspace.yaml` and in this description. Worth considering adding one to match `usdtb-ui` / `megausd-ui`, which both track their overrides in a `SECURITY.md`; raised as a follow-up rather than bundled here.

## Breaking changes

None. **No major version change in this PR** — the 6 → 7 redirect for `cacache` and `node-gyp` was already in effect on `main` (which resolved `tar@7.5.16`); this is a 7.5.16 → 7.5.20 patch bump within the same major.

## Rollback

No state migration — revert commit is sufficient. Reverting restores the vulnerable `tar@7.5.16`.
