### PR TITLE
fix(deps): remediate brace-expansion CVE-2026-13149 (and axios GHSA floor)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   axios@0.30.4: 0.30.3
   brace-expansion@<1.1.16: 1.1.16
   brace-expansion@>=2.0.0 <2.1.2: 2.1.2
-  brace-expansion@>=5.0.0 <5.0.8: 5.0.8
+  brace-expansion@>=3.0.0 <5.0.8: 5.0.8
   ip-address@<=10.1.0: 10.1.1
   uuid@11.1.0: 11.1.1
   ws@>=7.0.0 <7.5.11: 7.5.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,11 +8,12 @@ overrides:
   bigint-buffer: npm:bigint-buffer-fixed@^1.1.5
   tar: 7.5.20
   minimatch: '>=3.1.4'
-  axios: '>=1.16.0'
-  axios@1.14.1: '>=1.16.0'
+  axios: '>=1.18.0'
+  axios@1.14.1: '>=1.18.0'
   axios@0.30.4: 0.30.3
-  brace-expansion@<1.1.13: 1.1.13
-  brace-expansion@>=4.0.0 <5.0.6: 5.0.6
+  brace-expansion@<1.1.16: 1.1.16
+  brace-expansion@>=2.0.0 <2.1.2: 2.1.2
+  brace-expansion@>=5.0.0 <5.0.8: 5.0.8
   ip-address@<=10.1.0: 10.1.1
   uuid@11.1.0: 11.1.1
   ws@>=7.0.0 <7.5.11: 7.5.11
@@ -43,7 +44,7 @@ importers:
         specifier: ^1.95.2
         version: 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.7.3)(utf-8-validate@6.0.6)
       axios:
-        specifier: '>=1.16.0'
+        specifier: '>=1.18.0'
         version: 1.18.0
       base-x:
         specifier: ^5.0.1
@@ -72,7 +73,7 @@ packages:
     engines: {node: '>=15.10.0'}
     deprecated: This version is deprecated.  Please upgrade to version 2.1.0 or later.
     peerDependencies:
-      axios: '>=1.16.0'
+      axios: '>=1.18.0'
       got: ^11.8.6
 
   '@aptos-labs/aptos-dynamic-transaction-composer@0.1.5':
@@ -596,10 +597,6 @@ packages:
 
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
-
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -2804,10 +2801,6 @@ snapshots:
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
 
-  brace-expansion@5.0.6:
-    dependencies:
-      balanced-match: 4.0.4
-
   brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
@@ -3537,7 +3530,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.8
 
   minimatch@10.2.6:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,10 @@
 # Supply-chain hardening
 # Refuse to install package versions younger than 10 days
 minimumReleaseAge: 14400
+# Pre-existing lockfile entry younger than the age gate; exclude so CVE
+# override lockfile regeneration can proceed (already present on main).
+minimumReleaseAgeExclude:
+  - ip-address@10.4.0
 # Fail (don't silently downgrade) if a package's publisher trust level drops
 trustPolicy: no-downgrade
 # Known-benign provenance downgrades, vetted and exempted from no-downgrade.
@@ -25,11 +29,12 @@ overrides:
   # exactly: 7.5.20 is the newest release that clears `minimumReleaseAge` above.
   "tar": "7.5.20"
   "minimatch": ">=3.1.4"
-  "axios": ">=1.16.0"
-  "axios@1.14.1": ">=1.16.0"
+  "axios": ">=1.18.0"
+  "axios@1.14.1": ">=1.18.0"
   "axios@0.30.4": "0.30.3"
-  "brace-expansion@<1.1.13": "1.1.13"
-  "brace-expansion@>=4.0.0 <5.0.6": "5.0.6"
+  "brace-expansion@<1.1.16": "1.1.16"
+  "brace-expansion@>=2.0.0 <2.1.2": "2.1.2"
+  "brace-expansion@>=5.0.0 <5.0.8": "5.0.8"
   "ip-address@<=10.1.0": "10.1.1"
   "uuid@11.1.0": "11.1.1"
   "ws@>=7.0.0 <7.5.11": "7.5.11"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,8 @@
 minimumReleaseAge: 14400
 # Pre-existing lockfile entry younger than the age gate; exclude so CVE
 # override lockfile regeneration can proceed (already present on main).
+# TODO(2026-08-10): drop this once ip-address@10.4.0 clears minimumReleaseAge
+# (published 2026-07-31; 10-day gate ⇒ ~2026-08-10).
 minimumReleaseAgeExclude:
   - ip-address@10.4.0
 # Fail (don't silently downgrade) if a package's publisher trust level drops
@@ -29,12 +31,15 @@ overrides:
   # exactly: 7.5.20 is the newest release that clears `minimumReleaseAge` above.
   "tar": "7.5.20"
   "minimatch": ">=3.1.4"
+  # GHSA-gcfj-64vw-6mp9: Node HTTP adapter can inherit polluted proxy after
+  # interceptor config cloning; floor raised from >=1.16.0 to patched >=1.18.0.
   "axios": ">=1.18.0"
   "axios@1.14.1": ">=1.18.0"
   "axios@0.30.4": "0.30.3"
   "brace-expansion@<1.1.16": "1.1.16"
   "brace-expansion@>=2.0.0 <2.1.2": "2.1.2"
-  "brace-expansion@>=5.0.0 <5.0.8": "5.0.8"
+  # CVE-2026-13149: no patched 3.x/4.x exists — advisory remediates >=3.0.0 via 5.x
+  "brace-expansion@>=3.0.0 <5.0.8": "5.0.8"
   "ip-address@<=10.1.0": "10.1.1"
   "uuid@11.1.0": "11.1.1"
   "ws@>=7.0.0 <7.5.11": "7.5.11"


### PR DESCRIPTION
## What
Update brace-expansion overrides so leftover `5.0.6` is removed and `>=3.0.0 <5.0.8` consumers pin to `5.0.8`. Also raise the axios override floor to `>=1.18.0` for GHSA-gcfj-64vw-6mp9 (lockfile already resolved `1.18.0`).

## Why
CVE-2026-13149; lockfile still carried a vulnerable `5.0.6` resolution beside `5.0.8`. Axios floor was raised in the same change because the prior `>=1.16.0` override sits inside GHSA-gcfj-64vw-6mp9 (`>=1.15.2 <1.18.0`).

## Test Plan
- [x] `pnpm install --lockfile-only`
- [x] Lockfile has `brace-expansion@5.0.8` only (no `5.0.6`)
- [x] Lockfile has `axios@1.18.0`
- [ ] CI passes

## Security & Data Impact
**Security impact:** Fail-closed override/lockfile remediation for brace-expansion DoS and axios proxy-inheritance advisory.
**Data classification affected:** none
**Audit log updated:** n/a

## Notes
- `minimumReleaseAgeExclude` for `ip-address@10.4.0` is temporary (TODO drop after ~2026-08-10 when the 10-day age gate clears). Needed only to regenerate the lockfile; the package was already present on main.