### PR TITLE
fix(deps): widen uuid override for CVE-2026-41907

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   brace-expansion@>=2.0.0 <2.1.2: 2.1.2
   brace-expansion@>=3.0.0 <5.0.8: 5.0.8
   ip-address@<=10.1.0: 10.1.1
-  uuid@11.1.0: 11.1.1
+  uuid@<11.1.1: 11.1.1
   ws@>=7.0.0 <7.5.11: 7.5.11
   ws@>=8.0.0 <8.21.0: 8.21.0
   plain-crypto-js@4.2.1: 0.0.0-security
@@ -1703,11 +1703,6 @@ packages:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -3365,7 +3360,7 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       p-map: 3.0.0
       rimraf: 3.0.2
-      uuid: 8.3.2
+      uuid: 11.1.1
 
   istanbul-lib-report@3.0.1:
     dependencies:
@@ -3398,7 +3393,7 @@ snapshots:
       eyes: 0.1.8
       isomorphic-ws: 4.0.1(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       json-stringify-safe: 5.0.1
-      uuid: 8.3.2
+      uuid: 11.1.1
       ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
@@ -3416,7 +3411,7 @@ snapshots:
       isomorphic-ws: 4.0.1(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       json-stringify-safe: 5.0.1
       stream-json: 1.9.1
-      uuid: 8.3.2
+      uuid: 11.1.1
       ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
@@ -3773,7 +3768,7 @@ snapshots:
       '@types/ws': 8.5.14
       buffer: 6.0.3
       eventemitter3: 5.0.1
-      uuid: 8.3.2
+      uuid: 11.1.1
       ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       bufferutil: 4.0.9
@@ -3956,8 +3951,6 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@11.1.1: {}
-
-  uuid@8.3.2: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,7 +41,7 @@ overrides:
   # CVE-2026-13149: no patched 3.x/4.x exists — advisory remediates >=3.0.0 via 5.x
   "brace-expansion@>=3.0.0 <5.0.8": "5.0.8"
   "ip-address@<=10.1.0": "10.1.1"
-  "uuid@11.1.0": "11.1.1"
+  "uuid@<11.1.1": "11.1.1"
   "ws@>=7.0.0 <7.5.11": "7.5.11"
   "ws@>=8.0.0 <8.21.0": "8.21.0"
   "plain-crypto-js@4.2.1": "0.0.0-security"


### PR DESCRIPTION
## What
Widen the root pnpm uuid override to uuid@<11.1.1 → 11.1.1.

## Why
CVE-2026-41907 still flagged residual uuid@8.3.2 after the uuid@11.1.0 → 11.1.1 override.

## Test Plan
- [x] `pnpm install --lockfile-only`
- [x] Lockfile has no uuid@8
- [ ] CI lint/build passes

## Security & Data Impact
**Security impact:** Clears buffer bounds advisory. MAJOR for prior uuid 8 consumers.
**Data classification affected:** none
**Audit log updated:** n/a

## Breaking Changes
⚠️ MAJOR: transitive uuid 8 → 11.1.1 via pnpm override.