### PR TITLE
fix(deps): widen uuid 11.x override for CVE-2026-41907

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   axios@1.14.1: '>=1.18.0'
   axios@0.30.4: 0.30.3
   ip-address@<=10.1.0: 10.1.1
-  uuid@11.1.0: 11.1.1
+  uuid@>=11.0.0 <11.1.1: 11.1.1
   ws@>=7.0.0 <7.5.11: 7.5.11
   ws@>=8.0.0 <8.21.0: 8.21.0
   plain-crypto-js@4.2.1: 0.0.0-security
@@ -1287,10 +1287,6 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
-
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
 
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
@@ -3230,7 +3226,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 10.2.4
+      minimatch: 10.2.6
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -3531,10 +3527,6 @@ snapshots:
   mimic-response@1.0.1: {}
 
   mimic-response@3.1.0: {}
-
-  minimatch@10.2.4:
-    dependencies:
-      brace-expansion: 5.0.9
 
   minimatch@10.2.6:
     dependencies:
@@ -3894,7 +3886,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
-      minimatch: 10.2.4
+      minimatch: 10.2.6
 
   text-encoding-utf-8@1.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,7 +46,7 @@ overrides:
   # CVE-2026-13149: no patched 3.x/4.x exists — advisory remediates >=3.0.0 via 5.x
 
   "ip-address@<=10.1.0": "10.1.1"
-  "uuid@11.1.0": "11.1.1"
+  "uuid@>=11.0.0 <11.1.1": "11.1.1"
   "ws@>=7.0.0 <7.5.11": "7.5.11"
   "ws@>=8.0.0 <8.21.0": "8.21.0"
   "plain-crypto-js@4.2.1": "0.0.0-security"


### PR DESCRIPTION
## What
Widen uuid override from exact `uuid@11.1.0` to `uuid@>=11.0.0 <11.1.1` → `11.1.1`.

## Why
Clears remaining 11.x resolutions for CVE-2026-41907 / GHSA-w5hq-g745-h8pq without forcing uuid 8 → 11.

## Test plan
- [x] `pnpm install --lockfile-only`
- [x] Lockfile has `uuid@11.1.1` (no `11.1.0` / `11.0.x`)
- [ ] CI passes

## Security & Data Impact
**Security impact:** Clears uuid 11.x advisory slice. Residual uuid@8 deferred (major).
**Data classification affected:** none
**Audit log updated:** n/a

## Breaking Changes
None for this change. uuid@8 → 11 remains **MAJOR BUMP DEFERRED**.