### PR TITLE
fix(deps): widen uuid override to clear CVE-2026-41907

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   axios@1.14.1: '>=1.18.0'
   axios@0.30.4: 0.30.3
   ip-address@<=10.1.0: 10.1.1
-  uuid@>=11.0.0 <11.1.1: 11.1.1
+  uuid@<11.1.1: 11.1.1
   ws@>=7.0.0 <7.5.11: 7.5.11
   ws@>=8.0.0 <8.21.0: 8.21.0
   plain-crypto-js@4.2.1: 0.0.0-security
@@ -1703,11 +1703,6 @@ packages:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -3365,7 +3360,7 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       p-map: 3.0.0
       rimraf: 3.0.2
-      uuid: 8.3.2
+      uuid: 11.1.1
 
   istanbul-lib-report@3.0.1:
     dependencies:
@@ -3398,7 +3393,7 @@ snapshots:
       eyes: 0.1.8
       isomorphic-ws: 4.0.1(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       json-stringify-safe: 5.0.1
-      uuid: 8.3.2
+      uuid: 11.1.1
       ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
@@ -3416,7 +3411,7 @@ snapshots:
       isomorphic-ws: 4.0.1(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       json-stringify-safe: 5.0.1
       stream-json: 1.9.1
-      uuid: 8.3.2
+      uuid: 11.1.1
       ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
@@ -3769,7 +3764,7 @@ snapshots:
       '@types/ws': 8.5.14
       buffer: 6.0.3
       eventemitter3: 5.0.1
-      uuid: 8.3.2
+      uuid: 11.1.1
       ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       bufferutil: 4.0.9
@@ -3952,8 +3947,6 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@11.1.1: {}
-
-  uuid@8.3.2: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,7 +46,7 @@ overrides:
   # CVE-2026-13149: no patched 3.x/4.x exists — advisory remediates >=3.0.0 via 5.x
 
   "ip-address@<=10.1.0": "10.1.1"
-  "uuid@>=11.0.0 <11.1.1": "11.1.1"
+  "uuid@<11.1.1": "11.1.1"
   "ws@>=7.0.0 <7.5.11": "7.5.11"
   "ws@>=8.0.0 <8.21.0": "8.21.0"
   "plain-crypto-js@4.2.1": "0.0.0-security"


### PR DESCRIPTION
## What
Widen the root pnpm uuid override from `uuid@>=11.0.0 <11.1.1` to `uuid@<11.1.1` → `11.1.1`.

## Why
CVE-2026-41907 / Dependabot still flags residual uuid 8 (jayson, istanbul, rpc-websockets) after 11.x-only #175. Replaces deferred #173.

**Chains:** jayson, istanbul-lib-processinfo, rpc-websockets.

## Test plan
- [x] `pnpm install --lockfile-only`
- [x] Lockfile has no `uuid@8` / `9` / `10` package keys
- [ ] CI lint/build passes
- [ ] Smoke: wallet connect / RPC id generation if those surfaces exist on this repo

## Security & Data Impact
**Security impact:** Clears CVE-2026-41907 / GHSA-w5hq-g745-h8pq (buffer bounds on v3/v5/v6 when caller passes `buf`). Exploitability in these trees is low (`v4()` request IDs); this is to suppress Dependabot.
**Data classification affected:** none
**Audit log updated:** n/a

## Breaking Changes
⚠️ MAJOR: transitive `uuid` 8/9/10 → 11.1.1 via pnpm override. uuid 11 still ships CJS (12+ does not — not used). Rollback: revert the override key to `uuid@>=11.0.0 <11.1.1`.